### PR TITLE
Economy bugfix

### DIFF
--- a/src/CSM.csproj
+++ b/src/CSM.csproj
@@ -159,6 +159,7 @@
     <Compile Include="Helpers\ArrayHelpers.cs" />
     <Compile Include="Helpers\Tuple.cs" />
     <Compile Include="Injections\DistrictHandler.cs" />
+    <Compile Include="Injections\EconomyHandler.cs" />
     <Compile Include="Injections\NodeHandler.cs" />
     <Compile Include="Injections\PropHandler.cs" />
     <Compile Include="Injections\TerrainHandler.cs" />

--- a/src/Commands/Data/MoneyCommand.cs
+++ b/src/Commands/Data/MoneyCommand.cs
@@ -9,7 +9,7 @@ namespace CSM.Commands
     public class MoneyCommand : CommandBase
     {
         [ProtoMember(1)]
-        public long InternalMoneyAmount { get; set; }
+        public long MoneyAmount { get; set; }
 
         [ProtoMember(2)]
         public long[] TotalIncome { get; set; }

--- a/src/Commands/Handler/MoneyHandler.cs
+++ b/src/Commands/Handler/MoneyHandler.cs
@@ -13,13 +13,19 @@ namespace CSM.Commands.Handler
 
         public override void Handle(MoneyCommand command)
         {
-
-            typeof(EconomyManager).GetField("m_cashAmount", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(Singleton<EconomyManager>.instance, command.MoneyAmount);
-            typeof(EconomyManager).GetField("m_lastCashAmount", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(Singleton<EconomyManager>.instance, command.MoneyAmount);
+            if (MultiplayerManager.Instance.CurrentRole == MultiplayerRole.Server)
+            {
+                long __cashAmount = (long)typeof(EconomyManager).GetField("m_cashAmount", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(Singleton<EconomyManager>.instance);
+                __cashAmount += command.MoneyAmount;
+                typeof(EconomyManager).GetField("m_cashAmount", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(Singleton<EconomyManager>.instance, __cashAmount);
+                typeof(EconomyManager).GetField("m_lastCashAmount", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(Singleton<EconomyManager>.instance, __cashAmount);
+            }
 
             // Only on the client
             if (MultiplayerManager.Instance.CurrentRole == MultiplayerRole.Client)
             {
+                typeof(EconomyManager).GetField("m_cashAmount", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(Singleton<EconomyManager>.instance, command.MoneyAmount);
+                typeof(EconomyManager).GetField("m_lastCashAmount", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(Singleton<EconomyManager>.instance, command.MoneyAmount);
                 typeof(EconomyManager).GetField("m_totalExpenses", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(Singleton<EconomyManager>.instance, command.TotalExpenses);
                 typeof(EconomyManager).GetField("m_totalIncome", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(Singleton<EconomyManager>.instance, command.TotalIncome);
             }

--- a/src/Commands/Handler/MoneyHandler.cs
+++ b/src/Commands/Handler/MoneyHandler.cs
@@ -13,8 +13,9 @@ namespace CSM.Commands.Handler
 
         public override void Handle(MoneyCommand command)
         {
-            typeof(EconomyManager).GetField("m_cashAmount", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(Singleton<EconomyManager>.instance, command.InternalMoneyAmount);
-            typeof(EconomyManager).GetField("m_lastCashAmount", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(Singleton<EconomyManager>.instance, command.InternalMoneyAmount);
+
+            typeof(EconomyManager).GetField("m_cashAmount", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(Singleton<EconomyManager>.instance, command.MoneyAmount);
+            typeof(EconomyManager).GetField("m_lastCashAmount", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(Singleton<EconomyManager>.instance, command.MoneyAmount);
 
             // Only on the client
             if (MultiplayerManager.Instance.CurrentRole == MultiplayerRole.Client)

--- a/src/Extensions/EconomyExtension.cs
+++ b/src/Extensions/EconomyExtension.cs
@@ -46,14 +46,6 @@ namespace CSM.Extensions
             switch (MultiplayerManager.Instance.CurrentRole)
             {
                 case MultiplayerRole.Client:
-                    if (_lastMoneyAmount != (long)typeof(EconomyManager).GetField("m_cashAmount", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(Singleton<EconomyManager>.instance))
-                    {
-                        Command.SendToServer(new MoneyCommand
-                        {
-                            MoneyAmount = (long)typeof(EconomyManager).GetField("m_cashAmount", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(Singleton<EconomyManager>.instance)
-                        });
-                    }
-
                     if (!_LastserviceBudgetDay.SequenceEqual(_serviceBudgetDay) | !_LastserviceBudgetNight.SequenceEqual(_serviceBudgetNight))
                     {
                         Command.SendToServer(new BudgetChangeCommand
@@ -74,7 +66,6 @@ namespace CSM.Extensions
 
                         _Taxrate.CopyTo(_LastTaxrate, 0);
                     }
-
                     break;
 
                 case MultiplayerRole.Server:
@@ -113,35 +104,6 @@ namespace CSM.Extensions
 
             _lastMoneyAmount = (long)typeof(EconomyManager).GetField("m_cashAmount", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(Singleton<EconomyManager>.instance);
             return (internalMoneyAmount);
-        }
-
-        public override int OnAddResource(EconomyResource resource, int amount, Service service, SubService subService, Level level)
-        {
-            switch (MultiplayerManager.Instance.CurrentRole)
-            {
-                case MultiplayerRole.Client:
-                    {
-                        typeof(EconomyManager).GetField("m_taxMultiplier", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(Singleton<EconomyManager>.instance, 0);
-                        break;
-                    }
-            }
-            return amount;
-        }
-
-        public override int OnGetMaintenanceCost(int originalMaintenanceCost, Service service, SubService subService, Level level)
-        {
-            switch (MultiplayerManager.Instance.CurrentRole)
-            {
-                case MultiplayerRole.Client:
-                    {
-                        return 0;
-                    }
-                case MultiplayerRole.Server:
-                    {
-                        return originalMaintenanceCost;
-                    }
-            }
-            return originalMaintenanceCost;
         }
     }
 }

--- a/src/Extensions/EconomyExtension.cs
+++ b/src/Extensions/EconomyExtension.cs
@@ -50,7 +50,7 @@ namespace CSM.Extensions
                     {
                         Command.SendToServer(new MoneyCommand
                         {
-                            InternalMoneyAmount = (long)typeof(EconomyManager).GetField("m_cashAmount", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(Singleton<EconomyManager>.instance)
+                            MoneyAmount = (long)typeof(EconomyManager).GetField("m_cashAmount", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(Singleton<EconomyManager>.instance)
                         });
                     }
 
@@ -82,7 +82,7 @@ namespace CSM.Extensions
                     {
                         Command.SendToClients(new MoneyCommand
                         {
-                            InternalMoneyAmount = (long)typeof(EconomyManager).GetField("m_cashAmount", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(Singleton<EconomyManager>.instance),
+                            MoneyAmount = (long)typeof(EconomyManager).GetField("m_cashAmount", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(Singleton<EconomyManager>.instance),
                             TotalExpenses = (long[])typeof(EconomyManager).GetField("m_totalExpenses", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(Singleton<EconomyManager>.instance),
                             TotalIncome = (long[])typeof(EconomyManager).GetField("m_totalIncome", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(Singleton<EconomyManager>.instance)
                         });

--- a/src/Injections/EconomyHandler.cs
+++ b/src/Injections/EconomyHandler.cs
@@ -1,0 +1,102 @@
+﻿using ColossalFramework;
+using CSM.Commands;
+using Harmony;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+using CSM.Networking;
+using static EconomyManager;
+using ICities;
+
+
+namespace CSM.Injections
+{
+    class EconomyHandler
+    {
+    }
+
+    [HarmonyPatch(typeof(EconomyManager))]
+    [HarmonyPatch("AddResource")]
+    [HarmonyPatch(new Type[] { typeof(Resource), typeof(int), typeof(ItemClass.Service), typeof(ItemClass.SubService), typeof(ItemClass.Level), typeof(DistrictPolicies.Taxation) })]
+
+    public class AddResource
+    {
+        public static void Prefix(Resource resource, int amount, out object __state)
+        {
+            __state = amount;
+            //if (MultiplayerManager.Instance.CurrentRole == MultiplayerRole.Client)
+            {
+                switch (resource)
+                {
+                    case Resource.RewardAmount:
+                    case Resource.CitizenIncome:
+                    case Resource.PrivateIncome:
+                    case Resource.PublicIncome:
+                    case Resource.TourismIncome:
+                        {
+                            amount = 0;
+                            break;
+                        }
+
+                }
+            }
+            UnityEngine.Debug.Log($"{resource} added, amount: {amount}");
+        }
+    }
+
+    [HarmonyPatch(typeof(EconomyManager))]
+    [HarmonyPatch("AddResource")]
+    [HarmonyPatch(new Type[] { typeof(Resource), typeof(int), typeof(ItemClass.Service), typeof(ItemClass.SubService), typeof(ItemClass.Level), typeof(DistrictPolicies.Taxation) })]
+
+    public class AddResourcePostfix
+    {
+        public static void Postfix(int __state)
+        {
+            UnityEngine.Debug.Log($"postfix løber");
+        }
+    }
+
+
+    [HarmonyPatch(typeof(EconomyManager))]
+    [HarmonyPatch("FetchResource")]
+    [HarmonyPatch(new Type[] { typeof(Resource), typeof(int), typeof(ItemClass.Service), typeof(ItemClass.SubService), typeof(ItemClass.Level) })]
+    public class FetchResource
+    {
+        public static void Prefix(Resource resource, ref int amount)
+        {
+            //if (MultiplayerManager.Instance.CurrentRole == MultiplayerRole.Client)
+            {
+            
+                switch (resource)
+                {
+                    case Resource.CitizenIncome:
+                    case Resource.LoanPayment:
+                    case Resource.Maintenance:
+                    case Resource.PolicyCost:
+                        {
+                        amount = 0;
+                        //EconomyManager.instance.AddResource(Resource.RefundAmount, amount, ItemClass.Service.None, ItemClass.SubService.None,ItemClass.Level.None,DistrictPolicies.Taxation.None);
+                        break;
+                        }
+                    default:
+                        {
+                            Command.SendToAll(new MoneyCommand
+                            {
+                                MoneyAmount = amount,
+                            });
+                            break;
+                        }                        
+                }                               
+            }
+            UnityEngine.Debug.Log($"{resource} fetched, amount {amount}");
+
+            //if (MultiplayerManager.Instance.CurrentRole == MultiplayerRole.Server)
+            //{
+            //    UnityEngine.Debug.Log("virker stadig");
+            //}
+          
+        }
+    }
+
+}

--- a/src/Injections/NodeHandler.cs
+++ b/src/Injections/NodeHandler.cs
@@ -24,6 +24,7 @@ namespace CSM.Injections
         /// <param name="node">This is the node id set by CreateNode</param>
         public static void Postfix(bool __result, ref ushort node)
         {
+            UnityEngine.Debug.Log($"Create Node");
             if (__result)
             {
                 NetNode netNode = Singleton<NetManager>.instance.m_nodes.m_buffer[node];
@@ -47,6 +48,7 @@ namespace CSM.Injections
         /// <param name="data">The NetNode object</param>
         public static void Prefix(ushort node, ref NetNode data)
         {
+            UnityEngine.Debug.Log($"Release node");
             if (data.m_flags != 0 && !NodeHandler.IgnoreNodes.Contains(node))
             {
                 Command.SendToAll(new NodeReleaseCommand
@@ -73,6 +75,7 @@ namespace CSM.Injections
         /// <param name="node">The node id</param>
         public static void Postfix(ushort node)
         {
+            UnityEngine.Debug.Log($"Update Node Flags");
             NetNode netNode = Singleton<NetManager>.instance.m_nodes.m_buffer[node];
             ushort[] segments = new ushort[8];
             segments[0] = netNode.m_segment0;
@@ -105,6 +108,7 @@ namespace CSM.Injections
         {
             if (__result)
             {
+                UnityEngine.Debug.Log($"CreateSegment {segment}");
                 NetSegment seg = Singleton<NetManager>.instance.m_segments.m_buffer[segment];
                 Command.SendToAll(new SegmentCreateCommand
                 {
@@ -132,6 +136,7 @@ namespace CSM.Injections
         /// <param name="keepNodes">If adjacent nodes should also be released</param>
         public static void Prefix(ushort segment, ref NetSegment data, bool keepNodes)
         {
+            UnityEngine.Debug.Log($"Release segment");
             if (data.m_flags != 0 && !NodeHandler.IgnoreSegments.Contains(segment))
             {
                 Command.SendToAll(new SegmentReleaseCommand


### PR DESCRIPTION
Changes the economy code, to use harmony, to remove income and expences from the client. Also changes the code so the server acts as Master when it comes to cash.The client now sends the amount the money changes to the server, and this amount is added to or deducted from the money amount. The server sends the current amount of money to the clients, ensuring that all players always have the same amount of money.

As a bonus, this should remove the bug that unlocking of milestones results in double money reward, clients unlocking the milestone should no longer recieve any money